### PR TITLE
pending orders database

### DIFF
--- a/app/models/pending_order.rb
+++ b/app/models/pending_order.rb
@@ -1,0 +1,2 @@
+class PendingOrder < ApplicationRecord
+end

--- a/db/migrate/20190619233317_create_pending_orders.rb
+++ b/db/migrate/20190619233317_create_pending_orders.rb
@@ -1,0 +1,10 @@
+class CreatePendingOrders < ActiveRecord::Migration[5.1]
+  def change
+    create_table :pending_orders do |t|
+      t.string :id_oc
+      t.string :reception_date
+      t.string :max_dispatch_date
+      t.timestamps
+    end
+  end
+end

--- a/test/fixtures/pending_orders.yml
+++ b/test/fixtures/pending_orders.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/pending_order_test.rb
+++ b/test/models/pending_order_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PendingOrderTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Se creo modelo de PendingOrder para las ordenes pendientes FTP. 

El modelo tiene:
 - `id_oc`: id de la orden de compra (string)
- `reception_date`: fecha de recepcion de la orden (string)
- `max_dispatch_date`: Fecha máxima a despachar el pedido (string)

NOTA: Para guardar las ordenes en la BD se debe crear un objeto del modelo (ej pendingOrder.create(id_oc: ID, reception_date: fecha_1, max_dispatch_date: fecha_2)

`ID`, `fecha_1` y `fecha_2` son los parámetros a entregar